### PR TITLE
Upgrade some packages to ensure compatitability issues with python >= 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ examples/dask-worker-space
 .eggs/
 eggs/
 *.egg-info/
+dist/
+build/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astropy==4.3.1
+astropy==5.1
 beautifulsoup4==4.11.1
 bs4==0.0.1
 charset-normalizer==2.1.1
@@ -21,7 +21,7 @@ locket==1.0.0
 MarkupSafe==2.1.1
 matplotlib==3.5.3
 msgpack==1.0.4
-numpy==1.21.6
+numpy==1.23.4
 packaging==21.3
 pandas==1.3.5
 partd==1.3.0
@@ -35,7 +35,7 @@ pytz==2022.4
 PyYAML==6.0
 requests==2.28.1
 scikit-learn==1.0.2
-scipy==1.7.3
+scipy==1.9.2
 six==1.16.0
 sklearn==0.0
 sortedcontainers==2.4.0


### PR DESCRIPTION
I had some issues getting hipscat working on my local machine do some out of date packages, so I'm pushing those changes in case others have the same issues
- should still work fine with python 3.7, but now with more compatibility with 3.8 .9 & .10.
- tested in all 4 listed python versions on my local, the lincc-hub, and uw's baldur.
- also added some build stuff to the gitignore