### PR TITLE
End-to-end runners and alignment generation

### DIFF
--- a/src/partitioner/__main__.py
+++ b/src/partitioner/__main__.py
@@ -1,9 +1,24 @@
 """Main method to enable command line execution"""
+
 import sys
 
+import dask_runner
+import single_runner
 from arguments import PartitionArguments
+
+
+def run():
+    """Pick a runtime environment and run the partitioner"""
+    match args.runtime:
+        case "single":
+            single_runner.run(args)
+            return
+        case "dask":
+            dask_runner.run(args)
+            return
+
 
 if __name__ == "__main__":
     args = PartitionArguments()
     args.from_command_line(sys.argv[1:])
-    # TODO: everything else!
+    run()

--- a/src/partitioner/dask_runner.py
+++ b/src/partitioner/dask_runner.py
@@ -1,0 +1,48 @@
+"""Partitioner runner that uses dask for parallelization"""
+
+import numpy as np
+from dask.distributed import Client, progress
+
+import partitioner.histogram as hist
+import partitioner.io_utils as io
+from partitioner.arguments import PartitionArguments
+
+
+def _generate_histogram(args, client):
+    """Generate a raw histogram of object counts in each healpix pixel"""
+
+    futures = client.map(
+        hist.generate_partial_histogram,
+        args.input_paths,
+        highest_order=args.highest_healpix_order,
+        file_format=args.input_format,
+        ra_column=args.ra_column,
+        dec_column=args.dec_column,
+    )
+    progress(futures)
+
+    raw_histogram = hist.empty_histogram(args.highest_healpix_order)
+    for future in futures:
+        raw_histogram = np.add(raw_histogram, future.result())
+    return raw_histogram
+
+
+def run(args):
+    """Partitioner runner"""
+    if not args:
+        raise ValueError("partitioning arguments are required")
+    if not isinstance(args, PartitionArguments):
+        raise ValueError("args must be type PartitionArguments")
+    client = Client(
+        local_directory=args.dask_tmp,
+        n_workers=1,
+        threads_per_worker=1,
+    )
+    raw_histogram = _generate_histogram(args, client)
+
+    pixel_map = hist.generate_alignment(
+        raw_histogram, args.highest_healpix_order, args.pixel_threshold
+    )
+    io.write_legacy_metadata(args, raw_histogram, pixel_map)
+
+    # TODO - finish implementation

--- a/src/partitioner/histogram.py
+++ b/src/partitioner/histogram.py
@@ -97,7 +97,6 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
         parent_order = read_order - 1
         for index in range(0, len(nested_sums[read_order])):
             parent_pixel = index >> 2
-            # print(f"{read_order} : {index} : {parent_order} : {parent_pixel}")
             nested_sums[parent_order][parent_pixel] += nested_sums[read_order][index]
 
     nested_alignment = []
@@ -105,15 +104,13 @@ def generate_alignment(histogram, highest_order=10, threshold=1_000_000):
         nested_alignment.append(np.full(hp.order2npix(i), None))
 
     # work forward - determine if we should map to a lower order pixel, this pixel, or keep looking.
-    for index in range(0, len(nested_sums[0])):
-        if nested_sums[0][index] > 0 and nested_sums[0][index] <= threshold:
-            nested_alignment[0][index] = (0, index, nested_sums[0][index])
-
-    for read_order in range(1, highest_order + 1):
+    for read_order in range(0, highest_order + 1):
         parent_order = read_order - 1
         for index in range(0, len(nested_sums[read_order])):
-            parent_pixel = index >> 2
-            parent_alignment = nested_alignment[parent_order][parent_pixel]
+            parent_alignment = None
+            if parent_order >=0:
+                parent_pixel = index >> 2
+                parent_alignment = nested_alignment[parent_order][parent_pixel]
 
             if parent_alignment:
                 nested_alignment[read_order][index] = parent_alignment

--- a/src/partitioner/io_utils.py
+++ b/src/partitioner/io_utils.py
@@ -1,7 +1,9 @@
 """Utility functions for reading and writing files"""
 
+import json
 import os
 
+import numpy as np
 import pandas as pd
 from astropy.table import Table
 
@@ -16,7 +18,7 @@ def read_dataframe(path="", file_format="parquet") -> pd.DataFrame:
 
     Args:
         path (str): fully-specified path to the file
-        file_format (str): expected file format for the input file. This 
+        file_format (str): expected file format for the input file. This
             likely matches the extension of the file, but doesn't need to.
     Returns:
         dataframe with the data content at the target file
@@ -45,5 +47,84 @@ def read_dataframe(path="", file_format="parquet") -> pd.DataFrame:
     else:
         raise NotImplementedError(f"File Format: {file_format} not supported")
 
-
     return data_frame
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """Special json encoder for numpy types"""
+
+    def default(self, o):
+        obj = o
+        if isinstance(
+            obj,
+            (
+                np.int_,
+                np.intc,
+                np.intp,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+                np.ulonglong,
+            ),
+        ):
+            return int(obj)
+        if isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+            return float(obj)
+        if isinstance(obj, (np.ndarray,)):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
+
+def write_json_file(metadata_dictionary, file_name):
+    """Convert metadata_dictionary to a json string and print to file.
+    Args:
+        metadata_dictionary (:obj:`dictionary`): a dictionary of key-value pairs
+        file_name (str): destination for the json file
+    """
+    dumped_metadata = json.dumps(metadata_dictionary, indent=4, cls=NumpyEncoder)
+    with open(
+        file_name,
+        "w",
+        encoding="utf-8",
+    ) as metadata_file:
+        metadata_file.write(dumped_metadata + "\n")
+
+
+def write_legacy_metadata(args, histogram, pixel_map):
+    """Write a <catalog_name>_meta.json with the format expected by the prototype catalog implementation
+
+    Args:
+        args (:obj:`PartitionArguments`): collection of runtime arguments for the partitioning job
+        histogram (:obj:`np.array`): one-dimensional numpy array of long integers where the
+            value at each index corresponds to the number of objects found at the healpix pixel.
+        pixel_map (:obj:`np.array`): one-dimensional numpy array of integer 3-tuples.
+            See `histogram.generate_alignment` for more details on this format.
+    """
+    metadata = {}
+    metadata["cat_name"] = args.catalog_name
+    metadata["ra_kw"] = args.ra_column
+    metadata["dec_kw"] = args.dec_column
+    metadata["id_kw"] = args.id_column
+    metadata["n_sources"] = histogram.sum()
+    metadata["pix_threshold"] = args.pixel_threshold
+    metadata["urls"] = args.input_paths
+
+    hips_structure = {}
+    for item in pixel_map:
+        if not item:
+            continue
+        order = item[0]
+        pixel = item[1]
+        if order not in hips_structure:
+            hips_structure[order] = []
+        hips_structure[order].append(pixel)
+
+    metadata["hips"] = hips_structure
+
+    metadata_filename = os.path.join(args.output_path, f"{args.catalog_name}_meta.json")
+    write_json_file(metadata, metadata_filename)

--- a/src/partitioner/single_runner.py
+++ b/src/partitioner/single_runner.py
@@ -1,0 +1,40 @@
+"""Partitioner runner that doesn't use any parallelization mechanism"""
+
+import numpy as np
+
+import partitioner.histogram as hist
+import partitioner.io_utils as io_utils
+from partitioner.arguments import PartitionArguments
+
+
+def _generate_histogram(args):
+    """Generate a raw histogram of object counts in each healpix pixel"""
+
+    raw_histogram = hist.empty_histogram(args.highest_healpix_order)
+    for file_path in args.input_paths:
+
+        partial_histogram = hist.generate_partial_histogram(
+            file_path=file_path,
+            highest_order=args.highest_healpix_order,
+            file_format=args.input_format,
+            ra_column=args.ra_column,
+            dec_column=args.dec_column,
+        )
+        raw_histogram = np.add(raw_histogram, partial_histogram)
+
+    return raw_histogram
+
+
+def run(args):
+    """Partitioner runner"""
+    if not args:
+        raise ValueError("partitioning arguments are required")
+    if not isinstance(args, PartitionArguments):
+        raise ValueError("args must be type PartitionArguments")
+    raw_histogram = _generate_histogram(args)
+    pixel_map = hist.generate_alignment(
+        raw_histogram, args.highest_healpix_order, args.pixel_threshold
+    )
+    io_utils.write_legacy_metadata(args, raw_histogram, pixel_map)
+
+    # TODO - finish implementation

--- a/tests/partitioner/file_testing.py
+++ b/tests/partitioner/file_testing.py
@@ -5,12 +5,20 @@ import re
 
 
 def assert_text_file_matches(expected_lines, file_name):
-    """
-    Convenience method to read a text file and compare the contents,
-    line for line, against regular expressions.
+    """Convenience method to read a text file and compare the contents, line for line.
 
-    It can be easier to see differences in indivudual lines
-    when file contents grow to be large.
+    When file contents get even a little bit big, it can be difficult to see
+    the difference between an actual file and the expected contents without
+    increased testing verbosity. This helper compares files line-by-line,
+    using the provided strings or regular expressions.
+
+    Notes:
+        Because we check strings as regular expressions, you may need to escape some
+        contents of `expected_lines`.
+
+    Args:
+        expected_lines(:obj:`string array`) list of strings, formatted as regular expressions.
+        file_name (str): fully-specified path of the file to read
     """
     assert os.path.exists(file_name)
     metadata_file = open(
@@ -21,8 +29,12 @@ def assert_text_file_matches(expected_lines, file_name):
 
     contents = metadata_file.readlines()
 
-    assert len(expected_lines) == len(contents)
+    assert len(expected_lines) == len(
+        contents
+    ), f"files not the same length ({len(contents)} vs {len(expected_lines)})"
     for i, expected in enumerate(expected_lines):
-        assert re.match(expected, contents[i])
+        assert re.match(
+            expected, contents[i]
+        ), f"files do not match at line {i+1} (actual: [{contents[i]}] vs expected: [{expected}])"
 
     metadata_file.close()

--- a/tests/partitioner/file_testing.py
+++ b/tests/partitioner/file_testing.py
@@ -1,0 +1,28 @@
+"""Set of convenience methods for testing file contents"""
+
+import os
+import re
+
+
+def assert_text_file_matches(expected_lines, file_name):
+    """
+    Convenience method to read a text file and compare the contents,
+    line for line, against regular expressions.
+
+    It can be easier to see differences in indivudual lines
+    when file contents grow to be large.
+    """
+    assert os.path.exists(file_name)
+    metadata_file = open(
+        file_name,
+        "r",
+        encoding="utf-8",
+    )
+
+    contents = metadata_file.readlines()
+
+    assert len(expected_lines) == len(contents)
+    for i, expected in enumerate(expected_lines):
+        assert re.match(expected, contents[i])
+
+    metadata_file.close()

--- a/tests/partitioner/test_histogram.py
+++ b/tests/partitioner/test_histogram.py
@@ -55,6 +55,26 @@ def test_column_names():
     assert (result == expected).all()
 
 
+def test_alignment_wrong_size():
+    """Check that the method raises error when the input histogram is not the expected size."""
+    initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
+    with pytest.raises(ValueError):
+        hist.generate_alignment(initial_histogram, 0, 250)
+
+def test_alignment_exceeds_threshold_order0():
+    """Check that the method raises error when some pixel exceeds the threshold."""
+    initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
+    with pytest.raises(ValueError):
+        hist.generate_alignment(initial_histogram, 0, 20)
+
+def test_alignment_exceeds_threshold_order2():
+    """Check that the method raises error when some pixel exceeds the threshold."""
+    initial_histogram = hist.empty_histogram(2)
+    filled_pixels = [4, 11, 14, 13, 5, 7, 8, 9, 11, 23, 4, 4, 17, 0, 1, 0]
+    initial_histogram[176:] = filled_pixels[:]
+    with pytest.raises(ValueError):
+        hist.generate_alignment(initial_histogram, 2, 20)
+
 def test_alignment_small_sky_order0():
     """Create alignment from small sky's distribution at order 0"""
     initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])

--- a/tests/partitioner/test_histogram.py
+++ b/tests/partitioner/test_histogram.py
@@ -1,6 +1,8 @@
 """Tests of histogram calculations"""
 
 import data_paths as dc
+import healpy as hp
+import numpy as np
 import numpy.testing as npt
 import pytest
 
@@ -51,3 +53,54 @@ def test_column_names():
     expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8]
     npt.assert_array_equal(result, expected)
     assert (result == expected).all()
+
+
+def test_alignment_small_sky_order0():
+    """Create alignment from small sky's distribution at order 2"""
+    initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
+    result = hist.generate_alignment(initial_histogram, 0, 250)
+
+    expected = np.full(12, None)
+    expected[11] = (0, 11, 131)
+
+    npt.assert_array_equal(result, expected)
+
+
+def test_alignment_small_sky_order2():
+    """Create alignment from small sky's distribution at order 2"""
+    initial_histogram = hist.empty_histogram(2)
+    filled_pixels = [4, 11, 14, 13, 5, 7, 8, 9, 11, 23, 4, 4, 17, 0, 1, 0]
+    initial_histogram[176:] = filled_pixels[:]
+    result = hist.generate_alignment(initial_histogram, 2, 250)
+
+    expected = np.full(hp.order2npix(2), None)
+    tuples = [
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+        (0, 11, 131),
+    ]
+    expected[176:192] = tuples
+
+    npt.assert_array_equal(result, expected)
+
+
+def test_alignment_even_sky():
+    """Create alignment from an even distribution at order 8"""
+    initial_histogram = np.full(hp.order2npix(8), 10)
+    result = hist.generate_alignment(initial_histogram, 8, 1_000)
+    # everything maps to order 5, given the density
+    for mapping in result:
+        assert mapping[0] == 5

--- a/tests/partitioner/test_histogram.py
+++ b/tests/partitioner/test_histogram.py
@@ -56,7 +56,7 @@ def test_column_names():
 
 
 def test_alignment_small_sky_order0():
-    """Create alignment from small sky's distribution at order 2"""
+    """Create alignment from small sky's distribution at order 0"""
     initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
     result = hist.generate_alignment(initial_histogram, 0, 250)
 

--- a/tests/partitioner/test_io_utils.py
+++ b/tests/partitioner/test_io_utils.py
@@ -1,11 +1,16 @@
 """Tests of file IO (reads and writes)"""
 
+import os
+
 import data_paths as dc
+import file_testing as ft
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
 
 import partitioner.io_utils as io
+from partitioner.arguments import PartitionArguments
 
 
 def test_read_empty_filename():
@@ -42,3 +47,74 @@ def test_read_wrong_fileformat():
     """CSV file attempting to be read as parquet"""
     with pytest.raises(pa.lib.ArrowInvalid):
         io.read_dataframe(dc.TEST_SMALL_SKY_CSV, "parquet")
+
+
+def test_write_json_file():
+    """Test of arbitrary json dictionary with strings and numbers"""
+
+    expected_lines = [
+        "{\n",
+        '    "first_english": "a",',
+        '    "first_greek": "alpha",',
+        '    "first_number": 1,',
+        r'    "first_five_fib": \[',
+        "        1,",
+        "        1,",
+        "        2,",
+        "        3,",
+        "        5",
+        "    ]",
+        "}",
+    ]
+
+    dictionary = {}
+    dictionary["first_english"] = "a"
+    dictionary["first_greek"] = "alpha"
+    dictionary["first_number"] = 1
+    dictionary["first_five_fib"] = [1, 1, 2, 3, 5]
+
+    json_filename = os.path.join(dc.TEST_TMP_DIR, "dictionary.json")
+    io.write_json_file(dictionary, json_filename)
+    ft.assert_text_file_matches(expected_lines, json_filename)
+
+
+def test_write_legacy_metadata_file():
+    """Test that we can write out the older version of the partiion metadata"""
+    expected_lines = [
+        "{",
+        '    "cat_name": "small_sky",',
+        '    "ra_kw": "ra",',
+        '    "dec_kw": "dec",',
+        '    "id_kw": "id",',
+        '    "n_sources": 131,',
+        '    "pix_threshold": 1000000,',
+        r'    "urls": \[',
+        r'        ".*/tests/partitioner/data/small_sky/catalog.csv"',
+        "    ],",
+        '    "hips": {',
+        r'        "0": \[',
+        "            11",
+        "        ]",
+        "    }",
+        "}",
+    ]
+
+    args = PartitionArguments()
+    args.from_params(
+        catalog_name="small_sky",
+        input_path=dc.TEST_SMALL_SKY_DATA_DIR,
+        input_format="csv",
+        output_path=dc.TEST_TMP_DIR,
+        highest_healpix_order=0,
+        ra_column="ra",
+        dec_column="dec",
+    )
+    initial_histogram = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131])
+    pixel_map = np.full(12, None)
+    pixel_map[11] = (0, 11, 131)
+
+    io.write_legacy_metadata(args, initial_histogram, pixel_map)
+
+    metadata_filename = os.path.join(dc.TEST_TMP_DIR, "small_sky_meta.json")
+
+    ft.assert_text_file_matches(expected_lines, metadata_filename)

--- a/tests/partitioner/test_io_utils.py
+++ b/tests/partitioner/test_io_utils.py
@@ -79,7 +79,7 @@ def test_write_json_file():
 
 
 def test_write_legacy_metadata_file():
-    """Test that we can write out the older version of the partiion metadata"""
+    """Test that we can write out the older version of the partition metadata"""
     expected_lines = [
         "{",
         '    "cat_name": "small_sky",',

--- a/tests/partitioner/test_single_runner_end_to_end.py
+++ b/tests/partitioner/test_single_runner_end_to_end.py
@@ -1,0 +1,50 @@
+"""Test full exection of the un-parallelized runner"""
+
+
+import os
+
+import data_paths as dc
+import file_testing as ft
+
+import partitioner.single_runner as sr
+from partitioner.arguments import PartitionArguments
+
+
+def test_small_sky():
+    """Test loading the small sky catalog and partitioning each object into the same large bucket"""
+    args = PartitionArguments()
+    args.from_params(
+        catalog_name="small_sky",
+        input_path=dc.TEST_SMALL_SKY_DATA_DIR,
+        input_format="csv",
+        output_path=dc.TEST_TMP_DIR,
+        highest_healpix_order=0,
+        ra_column="ra",
+        dec_column="dec",
+    )
+
+    sr.run(args)
+
+    # Check that the legacy metadata file exists, and contains correct object data
+    expected_lines = [
+        "{",
+        '    "cat_name": "small_sky",',
+        '    "ra_kw": "ra",',
+        '    "dec_kw": "dec",',
+        '    "id_kw": "id",',
+        '    "n_sources": 131,',
+        '    "pix_threshold": 1000000,',
+        r'    "urls": \[',
+        r'        ".*/tests/partitioner/data/small_sky/catalog.csv"',
+        "    ],",
+        '    "hips": {',
+        r'        "0": \[',
+        "            11",
+        "        ]",
+        "    }",
+        "}",
+    ]
+    metadata_filename = os.path.join(dc.TEST_TMP_DIR, "small_sky_meta.json")
+    ft.assert_text_file_matches(expected_lines, metadata_filename)
+
+    # TODO - test that all other files are written to output directory


### PR DESCRIPTION
Implements 
- end-to-end runners to execute the partitioning pipeline in either a dask parallelization scheme, or without any parallelization
- method for reducing a raw histogram to the destination pixels
- method for printing out the metadata file expected by the current prototype catalog
- convenience methods for the above, that will be used in future pull requests as well.