### PR TITLE
small QoL fix for loading in catalog data on a local file system

### DIFF
--- a/hipscat/catalog.py
+++ b/hipscat/catalog.py
@@ -91,7 +91,10 @@ class Catalog():
 
         else: #assume local?
             if os.path.exists(file_source):
-                urls = glob.glob('{}*{}'.format(file_source, fmt))
+                fs_clean = file_source
+                if fs_clean[-1] != '/':
+                    fs_clean += '/'
+                urls = glob.glob('{}*{}'.format(fs_clean, fmt))
             else:
                 sys.exit('Local files not found at source {}'.format(file_source))
 


### PR DESCRIPTION
`os.path.exists` will return true when the provided `file_source` exists and doesn't end with a "/" character, but `glob` will be unable to find it. This causes the partitioner to report that no files were found at that location, even when there might be some available. Check to make sure that there's a trailing forward slash so that in the future someone else doesn't have to spend 10 minutes figuring out why they can't load from a directory that clearly exists 😛 