### PR TITLE
Code coverage calculation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
+          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,4 +33,3 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
-          name: codecov-umbrella

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,11 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --cov=partitioner --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,7 @@ jobs:
         run: |
           python -m pytest --cov=partitioner --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
-          flags: unittests
-          env_vars: OS,PYTHON
           name: codecov-umbrella
-          fail_ci_if_error: true


### PR DESCRIPTION
Calculate code coverage and upload to codecov.

Also added a repo secret with the Codecov upload token. While this is not strictly necessary for a public repo, user reports indicate this reduces flakiness in the upload process.