### PR TITLE
prototype of the margin caching code

### DIFF
--- a/hipscat/dask_utils.py
+++ b/hipscat/dask_utils.py
@@ -205,8 +205,8 @@ def _to_neighbor_cache(df, hipsPath, base_filename, ra_kw, dec_kw):
     resolution = hp.nside2resol(2**k, arcmin=True) / 60.
     resolution_and_thresh = resolution + 0.1
     scale = (resolution_and_thresh**2) / (resolution**2)
-    scale_matrix = np.array([scale, 0],
-                            [0, scale])
+    scale_matrix = np.array([[scale, 0],
+                            [0, scale]])
 
     # create the rough boundaries of the threshold bounding region.
     # TODO: create a scaling affine transform that will scale this region to cover the

--- a/hipscat/dask_utils.py
+++ b/hipscat/dask_utils.py
@@ -12,6 +12,8 @@ import dask.dataframe as dd
 import dask
 
 from astropy.table import Table
+from astropy.coordinates import SkyCoord
+from regions import PixCoord, PolygonSkyRegion, PolygonPixelRegion
 from functools import partial
 from dask.distributed import Client, progress
 from dask.delayed import delayed
@@ -62,7 +64,7 @@ def _gather_statistics_hpix_hist(parts, k, cache_dir, fmt, ra_kw, dec_kw):
     return img
 
 
-def _write_partition_structure(url, cache_dir, output_dir, orders, opix, ra_kw, dec_kw, id_kw):
+def _write_partition_structure(url, cache_dir, output_dir, orders, opix, ra_kw, dec_kw, id_kw, neighbor_pix, highest_k):
 
     base_filename = os.path.basename(url).split('.')[0]
     parqFn = os.path.join(cache_dir, base_filename + '.parquet')
@@ -73,6 +75,15 @@ def _write_partition_structure(url, cache_dir, output_dir, orders, opix, ra_kw, 
         ra_kw = df.keys()[ra_kw]
         dec_kw = df.keys()[dec_kw]
         id_kw = df.keys()[id_kw]
+
+    # write the margin data
+    df['margin_pix'] = hp.ang2pix(2**highest_k, df[ra_kw].values, df[dec_kw].values, lonlat=True, nest=True)
+
+    neighbor_cache_df = df.merge(neighbor_pix, on='margin_pix')
+
+    res = neighbor_cache_df.groupby(['part_pix', 'part_order']).apply(_to_neighbor_cache, hipsPath=output_dir, base_filename=base_filename, ra_kw=ra_kw, dec_kw=dec_kw)
+
+    del neighbor_cache_df
 
     for k in orders:
         df['hips_k'] = k
@@ -100,25 +111,50 @@ def _map_reduce(output_dir):
     #print(output_dirs)
     #for output_dir in output_dirs:
 
-    dfs = []
+    cat_dfs = []
     files = os.listdir(os.path.join(output_dir))
-    if len(files) == 1:
-        fn = os.path.join(output_dir, files[0])
+    catalog_files = list(filter(lambda f: len(f) > 15 and f[-15:] == 'catalog.parquet', files))
+    neighbor_files = list(filter(lambda f: len(f) > 16 and f[-16:] == 'neighbor.parquet', files))
+    if len(catalog_files) == 1:
+        fn = os.path.join(output_dir, catalog_files[0])
         df = pd.read_parquet(fn, engine='pyarrow')
         new_fn = os.path.join(output_dir, 'catalog.parquet')
         os.rename(fn, new_fn)
         #shutil.copyfile(fn, new_fn)
     else:
-        for f in files:
+        for f in catalog_files:
             fn = os.path.join(output_dir, f)
-            dfs.append(pd.read_parquet(fn, engine='pyarrow'))
+            cat_dfs.append(pd.read_parquet(fn, engine='pyarrow'))
             os.remove(fn)
 
-        df = pd.concat(dfs, sort=False)
+        df = pd.concat(cat_dfs, sort=False)
         output_fn = os.path.join(output_dir, 'catalog.parquet')
         df.to_parquet(output_fn)
 
     del df
+    del cat_dfs
+
+    nei_dfs = []
+
+    if len(neighbor_files) == 1:
+        fn = os.path.join(output_dir, neighbor_files[0])
+        df = pd.read_parquet(fn, engine='pyarrow')
+        new_fn = os.path.join(output_dir, 'neighbor.parquet')
+        os.rename(fn, new_fn)
+        #shutil.copyfile(fn, new_fn)
+    else:
+        for f in neighbor_files:
+            fn = os.path.join(output_dir, f)
+            nei_dfs.append(pd.read_parquet(fn, engine='pyarrow'))
+            os.remove(fn)
+
+        df = pd.concat(nei_dfs, sort=False)
+        output_fn = os.path.join(output_dir, 'neighbor.parquet')
+        df.to_parquet(output_fn)
+
+    del df
+    del nei_dfs
+
     return 0
 
 
@@ -154,6 +190,62 @@ def _to_hips(df, hipsPath, base_filename):
     # return the number of records written
     return len(df)
 
+def _to_neighbor_cache(df, hipsPath, base_filename, ra_kw, dec_kw):
+    # WARNING: only to be used from df2hips(); it's defined out here just for debugging
+    # convenience.
+
+    # grab the order and pix number for this dataframe. Since this function
+    # is intented to be called with apply() after running groupby on (k, pix), these must
+    # be the same throughout the entire dataframe
+    output_parquet = True
+    k, pix = df['part_order'].iloc[0],  df['part_pix'].iloc[0]
+    assert (df['part_pix'] == pix).all()
+    assert (df['part_order']   ==   k).all()
+
+    resolution = hp.nside2resol(2**k, arcmin=True) / 60.
+    resolution_and_thresh = resolution + 0.1
+    scale = (resolution_and_thresh**2) / (resolution**2)
+    scale_matrix = np.array([scale, 0],
+                            [0, scale])
+
+    # create the rough boundaries of the threshold bounding region.
+    # TODO: create a scaling affine transform that will scale this region to cover the
+    # necessary threshold.
+    pixel_boundaries = hp.vec2ang(hp.boundaries(2**k, pix, nest=True), lonlat=True)
+    vertices = PixCoord(x=pixel_boundaries[0], y=pixel_boundaries[1])
+    pixel_region = PolygonPixelRegion(vertices=vertices)
+
+    df['margin_check'] = _check_margin_bounds(df[ra_kw].values, df[dec_kw].values, pixel_region)
+
+    margin_df = df.loc[df['margin_check'] == True]
+
+    # construct the output directory and filename
+    dir = os.path.join(hipsPath, f'Norder{k}/Npix{pix}')
+    if output_parquet:
+        fn  = os.path.join(dir, f'{base_filename}_neighbor.parquet')
+    else:
+        fn  = os.path.join(dir, f'{base_filename}_neighbor.csv')
+
+    # create dir if it doesn't exist
+    os.makedirs(dir, exist_ok=True)
+
+    # write to the file (append if it already exists)
+    # also, write the header only if the file doesn't already exist
+    if output_parquet:
+        margin_df.to_parquet(fn)
+    else:
+        margin_df.to_csv(fn, mode='a', index=False, header=not os.path.exists(fn))
+
+    # return the number of records written
+    return len(df)
+
+def _check_margin_bounds(ra, dec, pixel_region):
+    res = []
+    for i in range(len(ra)):
+        sc = PixCoord(x=ra[i], y=dec[i])
+        in_bounds = pixel_region.contains(sc)
+        res.append(in_bounds)
+    return res
 
 def _cross_match2(match_cats, c1_md, c2_md, c1_cols=[], c2_cols=[],  n_neighbors=1, dthresh=0.01):
 
@@ -228,13 +320,13 @@ def _cross_match2(match_cats, c1_md, c2_md, c1_cols=[], c2_cols=[],  n_neighbors
 
 def xmatch_from_daskdf(df, c1_md, c2_md, c1_cols, c2_cols,n_neighbors=1, dthresh=0.01):
     '''
-    mapped function for calculating a cross_match between a partitioned dataframe 
+    mapped function for calculating a cross_match between a partitioned dataframe
      with columns [C1, C2, Order, Pix, ToCull1, ToCull2]
         C1 is the pathway to the catalog1.parquet file
         C2 is the pathway to the catalog2.parquet file
         Order is the healpix order
         Pix is the healpix pixel at the order for the calculation
-        ToCull1 is a boolean which represents the original C1 file's healpix order > 
+        ToCull1 is a boolean which represents the original C1 file's healpix order >
             than C2, thus the number of sources is potentiall 4 times greater than
             the number of sources in C2. We can optimize the comparison calculation
             by culling the sources from C1 that aren't in C2's order/pixel
@@ -242,7 +334,7 @@ def xmatch_from_daskdf(df, c1_md, c2_md, c1_cols, c2_cols,n_neighbors=1, dthresh
     '''
 
     vals = zip(
-        df['C1'], 
+        df['C1'],
         df['C2'],
         df['Order'],
         df['Pix'],
@@ -261,7 +353,7 @@ def xmatch_from_daskdf(df, c1_md, c2_md, c1_cols, c2_cols,n_neighbors=1, dthresh
 
         # TODO: enforcemetadata=False
         # TODO: select columns in the pd.read_parquet(...) command
-        # try/except is here because when enforcemetadata=True, it passes in 
+        # try/except is here because when enforcemetadata=True, it passes in
         #  a test-dataframe that has values for filepaths as 'foo'/'bar'
         #  which breaks opening the pandas.read_parquet()
         try:
@@ -287,19 +379,19 @@ def xmatch_from_daskdf(df, c1_md, c2_md, c1_cols, c2_cols,n_neighbors=1, dthresh
                 cols=c2_cols,
                 tocull=tocull2
             )
-            
-            #Sometimes the c1_df or c2_df contain zero sources 
+
+            #Sometimes the c1_df or c2_df contain zero sources
             # after culling
             if len(c1_df) and len(c2_df):
 
-                #calculate the xy gnomonic positions from the 
+                #calculate the xy gnomonic positions from the
                 # pixel's center for each dataframe
                 xy1 = util.frame_gnomonic(c1_df, c1_md, clon, clat)
                 xy2 = util.frame_gnomonic(c2_df, c2_md, clon, clat)
 
                 #construct the KDTree from the comparative catalog: c2/xy2
                 tree = KDTree(xy2, leaf_size=2)
-                #find the indicies for the nearest neighbors 
+                #find the indicies for the nearest neighbors
                 #this is the cross-match calculation
                 dists, inds = tree.query(xy1, k=n_neighbors)
 

--- a/hipscat/margin_utils.py
+++ b/hipscat/margin_utils.py
@@ -1,0 +1,195 @@
+#
+# Healpix utilities
+#
+
+import numpy as np
+import healpy as hp
+
+# see the documentation for get_edge() about this variable
+_edge_vectors = [
+    np.asarray([1, 3]), # NE edge
+    np.asarray([1]),    # E corner
+    np.asarray([0, 1]), # SE edge
+    np.asarray([0]),    # S corner
+    np.asarray([0, 2]), # SW edge
+    np.asarray([2]),    # W corner
+    np.asarray([2, 3]), # NW edge
+    np.asarray([3])     # N corner
+]
+
+# cache used by get_margin()
+_suffixes = {}
+
+def get_edge(dk, pix, edge):
+    # Given a pixel pix of at some order, return all
+    # pixels order dk _higher_ than pix's order that line
+    # pix's edge (or a corner).
+    #
+    # pix: the pixel ID for which the margin is requested
+    # dk: the requested order of edge pixel IDs, relative to order of pix
+    # edge: which edge/corner to return (NE edge=0, E corner=1, SE edge = 2, ....)
+    #
+    # ## Algorithm:
+    #
+    # If you look at how the NEST indexing scheme works, a pixel at some order is
+    # subdivided into four subpixel at every subsequent order in such a way that the south
+    # subpixel index equals 4*pix, east is 4*pix+1, west is 4*pix+2, north is 4*pix+3:
+    #
+    #                   4*pix+3
+    #   pix ->     4*pix+2    4*pix+1
+    #                    4*pix
+    #
+    # Further subdivisions split up each of those sub pixels accordingly. For example,
+    # the eastern subpixel (4*pix+1) gets divide up into four more:
+    #
+    #     S=4*(4*pix+1), E=4*(4*pix+1)+1, W=4*(4*pix+1)+2, N=4*(4*pix+1)+3
+    #
+    #                                                               4*(4*pix+3)+3
+    #                   4*pix+3                             4*(4*pix+3)+2   4*(4*pix+3)+1
+    #                                               4*(4*pix+2)+3   4*(4*pix+3)   4*(4*pix+1)+3
+    #   pix ===>  4*pix+2    4*pix+1  ===>  4*(4*pix+2)+2   4*(4*pix+2)+1   4*(4*pix+1)+2   4*(4*pix+1)+1
+    #                                                4*(4*pix+2)    4*(4*pix)+3    4*(4*pix+1)
+    #                    4*pix                                4*(4*pix)+2   4*(4*pix)+1
+    #                                                                  4*(4*pix)
+    # etcetera...
+    #
+    # We can see that the edge indices follow a pattern. For example, after two
+    # subdivisions the south-east edge would consist of pixels:
+    #     4*(4*pix), 4*(4*pix)+1
+    #     4*(4*pix+1), 4*(4*pix+1)+1
+    # with the top coming from subdividing the southern, and bottom the eastern pixel.
+    # and so on, recursively, for more subdivisions. Similar patterns are identifiable
+    # with other edges.
+    #
+    # This can be compactly written as:
+    #
+    #   4*(4*(4*pix + i) + j) + k ....
+    #
+    # with i, j, k, ... being indices whose choice specifies which edge we get.
+    # For example iterating through, i = {0, 1}, j = {0, 1}, k = {0, 1} generates indices
+    # for the 8 pixels of the south-east edge for 3 subdivisions. Similarly, for
+    # the north-west edge the index values would loop through {2, 3}, etc.
+    #
+    # This can be expanded as:
+    #
+    #   4**dk*pix  +  4**(dk-1)*i + 4**(dk-2)*j + 4**(dk-3) * k + ...
+    #
+    # where dk is the number of subdivisions. E.g., for dk=3, this would equal:
+    #
+    #   4**3*pix + 4**2*i + 4**1*j + k
+    #
+    # When written with bit-shift operators, another interpretation becomes clearer:
+    #
+    #   pix << 6 + i << 4 + j << 2 + k
+    #
+    # or if we look at the binary representation of the resulting number:
+    #
+    #   [pix][ii][jj][kk]
+    #
+    # Where ii, jj, kk are the bits of _each_ of the i,j,k indices. That is, to get the
+    # list of subpixels on the edge, we bit-shift the base index pix by 2*dk to the left,
+    # and fill in the rest with all possible combinations of ii, jj, kk indices. For example,
+    # the northeast edge has index values {2, 3} = {0b10, 0b11}, so for (say) pix=8=0b1000, the
+    # northeast edge indices after two subdivisions are equal to:
+    #
+    #   0b1000 10 10 = 138
+    #   0b1000 10 11 = 139
+    #   0b1000 11 10 = 148
+    #   0b1000 11 11 = 143
+    #
+    # Note that for a given edge and dk, the suffix of each edge index does not depend on
+    # the value of pix (pix is bit-shifted to the right and added). This means it can be
+    # precomputed & stored for repeated reuse.
+    #
+    # ## Implementation:
+    #
+    # The implementation is based on the binary digit interpretation above. For a requested
+    # edge and dk subdivision level, we generate (and cache) the suffixes. Then, for a given
+    # pixel pix, the edge pixels are readily computed by left-shifting pix by 2*dk places,
+    # and summing (== or-ing) it with the suffix array.
+    #
+
+    try:
+        a = _suffixes[(edge, dk)]
+    except KeyError:
+        # generate and cache the suffix:
+
+        # generate all combinations of i,j,k,... suffixes for the requested edge
+        # See https://stackoverflow.com/a/35608701 if you're confused.
+        a = np.array(np.meshgrid(*[_edge_vectors[edge]]*dk)).T.reshape(-1, dk)
+        # bit-shift each suffix by the required number of bits
+        a <<= np.arange(2*(dk-1),-2,-2)
+        # sum them up row-wise, generating the suffix
+        a = a.sum(axis=1)
+        # cache for further reuse
+        _suffixes[(edge, dk)] = a
+
+    # append the 'pix' preffix
+    a = (pix << 2*dk) + a
+    return a
+
+def get_margin(kk, pix, dk):
+    # Returns the list of indices of pixels of order (kk+dk) that
+    # border the pixel pix of order kk.
+    #
+    # Algorithm: given a pixel pix, find all of its neighbors. Then find the
+    # edge at level (kk+dk) for each of the neighbors.
+    #
+    # This is relatively straightforward in the equatorial faces of the Healpix
+    # sphere -- e.g., one takes the SW neighbor and requests its NE edge to get
+    # the margin on that side of the pixel, then the E corner of the W neighbor,
+    # etc...
+    #
+    # This breaks down on pixels that are at the edge of polar faces. There,
+    # the neighbor's sense of direction _rotates_ when switching from face to
+    # face. For example at order=2, pixel 5 is bordered by pixel 26 to the
+    # northeast (see the Fig3, bottom, https://healpix.jpl.nasa.gov/html/intronode4.htm).
+    # But to pixel 5 that is the **northwest** edge (and not southwest, as you'd
+    # expect; run hp.get_all_neighbours(4, 26, nest=True) and
+    # hp.get_all_neighbours(4, 5, nest=True) to verify these claims.)
+    #
+    # This is because directions rotate 90deg clockwise when moving from one
+    # polar face to another in easterly direction (e.g., from face 0 to face 1).
+    # We have to identify when this happens, and change the edges we request
+    # for such neighbors. Mathematically, this rotation is equal to adding +2
+    # (modulo 8) to the requested edge in get_edge(). I.e., for the
+    # pixel 5 example, rather than requesting SE=4 edge of pixel 26,
+    # we request SE+2=6=NE edge (see the comments in the definition of _edge_vectors
+    # near get_edge())
+    #
+    # This index shift generalizes to 2*(neighbor_face - pix_face) for the case
+    # when _both_ faces are around the pole (either north or south). In the south,
+    # the rotation is in the opposite direction (ccw) -- so the sign of the shift
+    # changes. The generalized formula also handles the pixels whose one vertex
+    # is the pole (where all three neighbors sharing that vertex are on different
+    # faces).
+    #
+    # Implementation: pretty straightforward implementation of the algorithm
+    # above.
+    #
+    nside = hp.order2nside(kk)
+
+    # get all neighboring pixels
+    n = hp.get_all_neighbours(nside, pix, nest=True)
+
+    # get the healpix faces IDs of pix and the neighboring pixels
+    _, _, f0 = hp.pix2xyf(nside, pix, nest=True)
+    _, _, f  = hp.pix2xyf(nside, n, nest=True)
+
+    # indices which tell get_edge() which edge/verted to return
+    # for a given pixel. The default order is compatible with the
+    # order returned by hp.get_all_neighbours().
+    which = np.arange(8)
+    if f0 < 4: # northern hemisphere; 90deg cw rotation for every +1 face increment
+        mask = (f < 4)
+        which[mask] += 2*(f-f0)[mask]
+        which %= 8
+    elif f0 >= 8: # southern hemisphere; 90deg ccw rotation for every +1 face increment
+        mask = (f >= 8)
+        which[mask] -= 2*(f-f0)[mask]
+        which %= 8
+
+    # get all edges/vertices (making sure we skip -1 entries, for pixels with seven neighbors)
+    nb = list(get_edge(dk, px, edge) for edge, px in zip(which, n) if px != -1)
+    nb = np.concatenate(nb)
+    return nb

--- a/hipscat/margin_utils.py
+++ b/hipscat/margin_utils.py
@@ -115,7 +115,7 @@ def get_edge(dk, pix, edge):
         # generate and cache the suffix:
 
         # generate all combinations of i,j,k,... suffixes for the requested edge
-        # See https://stackoverflow.com/a/35608701 if you're confused.
+        # See https://stackoverflow.com/a/35608701
         a = np.array(np.meshgrid(*[_edge_vectors[edge]]*dk)).T.reshape(-1, dk)
         # bit-shift each suffix by the required number of bits
         a <<= np.arange(2*(dk-1),-2,-2)

--- a/hipscat/margin_utils.py
+++ b/hipscat/margin_utils.py
@@ -108,10 +108,9 @@ def get_edge(dk, pix, edge):
     # pixel pix, the edge pixels are readily computed by left-shifting pix by 2*dk places,
     # and summing (== or-ing) it with the suffix array.
     #
-
-    try:
+    if (edge, dk) in _suffixes.keys():
         a = _suffixes[(edge, dk)]
-    except KeyError:
+    else:
         # generate and cache the suffix:
 
         # generate all combinations of i,j,k,... suffixes for the requested edge

--- a/hipscat/partitioner.py
+++ b/hipscat/partitioner.py
@@ -47,7 +47,7 @@ class Partitioner():
 
         # the order at which we will preform the margin pixel assignments
         # needs to be equal to or greater than the highest order of partition.
-        self.highest_k = 7
+        self.highest_k = order_k + 1
 
         assert self.fmt in ['csv', 'parquet', 'csv.gz', 'fits'], \
             'Source catalog file format not implemented. csv, csv.gz, fits, and parquet\


### PR DESCRIPTION
closes #11 
This is a prototype! the one thing left to do before it's feature ready would be to properly scale the bounding boxes for margin checking to actually fit the threshold scale. (step 4 in this list)
## Current Code Functionality
- when creating the `opix` partitioning map, we also store all the margin pixels (pixels that directly border the partition pixel) at a higher order `highest_k`.
- during the mapping phase, we use healpix to quickly assign all data points a pixel at `highest_k`.
- We then merge the `neighbor_pix` store of associations with the data on the `margin_pix`, which gives us a list of all the data that belongs to one or more partition's neighbor cache.
- We then have a much more precise check to see if the data is within the threshold of the given partition pixel. we do this by creating an approximate bounding box from the `healpy.boundaries` method and using an astropy regions `PolygonPixelRegion`, which allows us to quickly see if a given point is within the bounded area.
- We then map and reduce it into a `neighbors.parquet` file like we do with the catalog data.
## Performance
The gathering statistics portion of the import does take a little longer, by a couple tenths of a second (order of seconds originally) and I haven't noticed a significant increase in compute time during the map reduce phase. Run on a ~2 million source segment of the gaia catalog (first 10 files).
## Future
This original code should live on in the LSD2 prototype repo. I'm going to start working an actual production version of it into the [hipscat-import](https://github.com/astronomy-commons/hipscat-import) repo. Tracked in issue https://github.com/astronomy-commons/hipscat-import/issues/12